### PR TITLE
Make use of dl_esm_inf infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 *.exe
 *.o
+*.mod
+*.MOD

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "src/shared/dl_timer"]
 	path = src/shared/dl_timer
 	url = https://bitbucket.org/apeg/dl_timer
+[submodule "src/shared/dl_esm_inf"]
+	path = src/shared/dl_esm_inf
+	url = git@github.com:stfc/dl_esm_inf.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://bitbucket.org/apeg/dl_timer
 [submodule "src/shared/dl_esm_inf"]
 	path = src/shared/dl_esm_inf
-	url = git@github.com:stfc/dl_esm_inf.git
+	url = https://github.com/stfc/dl_esm_inf.git

--- a/README.md
+++ b/README.md
@@ -6,15 +6,27 @@ Investigation into the use of Domain Specific Languages with the NEMO ocean mode
 
 The benchmark codes contained in this project use the
 [dl_timer](https://bitbucket.org/apeg/dl_timer) library for execution
-timing. This code is included within the NEMO-DSL repository as a git submodule.
-As such, when cloning the repository you need to use the `--recursive` flag in
-order to get the source code of that submodule, e.g.:
+timing and the [dl_esm_inf](https://github.com/stfc/dl_esm_inf)
+infrastructure. These packages are included within the NEMO-DSL repository
+as git submodules.  As such, when cloning the repository you need to
+use the `--recursive` flag in order to get the source code of that
+submodule, e.g.:
 
     git clone --recursive https://github.com/arporter/NEMO-DSL
 
-If you forget to do this then your cloned repository will contain an empty
-`NEMO-DSL/src/shared/dl_timer` directory. To populate it you can do:
+If you forget to do this then your cloned repository will contain
+empty `NEMO-DSL/src/shared/dl_timer` and `dl_esm_inf` directories. To
+populate them you can do:
 
     cd NEMO-DSL
     git submodule init
     git submodule update
+
+## PSyKAl Version of the Code ##
+
+The `src/psykal` directory contains a version of the benchmark code
+that has been re-structured following the Parallel System Kernel
+Algorithm (PSyKAl) separation of concerns. It also makes use of the
+dl_esm_inf infrastructure support for the creation of grid and field
+objects.
+

--- a/src/psykal/Makefile
+++ b/src/psykal/Makefile
@@ -10,15 +10,19 @@ all: tra_adv.exe
 
 # Location of the dl_timer code
 TIMER_DIR = ../shared/dl_timer
+INF_DIR = ../shared/dl_esm_inf/finite_difference
 
-FORT_FLAGS = ${F90FLAGS} -I${TIMER_DIR}/src
+# Append the locations of the various library modules to the
+# list of compiler flags
+FORT_FLAGS = ${F90FLAGS} -I${TIMER_DIR}/src -I${INF_DIR}/src
 
 KERN_OBJ = zind_kern.o zwxy_kern.o zslpxy_kern.o zslpxy_update_kern.o zwxy2_kern.o \
 	   mydomain_update_kern.o zwx_kern.o zslpx_kern.o zslpx_update_kern.o \
 	   zwx2_kern.o mydomain_kern.o
 
-tra_adv.exe: timer_lib ${KERN_OBJ} psy.o tra_adv_alg.o
-	${F90} -o $@ tra_adv_alg.o psy.o ${KERN_OBJ} ${TIMER_DIR}/dl_timer_lib.a
+tra_adv.exe: timer_lib inf_lib ${KERN_OBJ} psy.o tra_adv_alg.o
+	${F90} -o $@ tra_adv_alg.o psy.o ${KERN_OBJ} \
+        ${TIMER_DIR}/dl_timer_lib.a ${INF_DIR}/src/dl_esm_inf_fd.a
 
 %.o: %.f90
 	${F90} ${FORT_FLAGS} -c $<
@@ -27,6 +31,9 @@ tra_adv.exe: timer_lib ${KERN_OBJ} psy.o tra_adv_alg.o
 
 timer_lib:
 	make -C ${TIMER_DIR} sm_lib
+
+inf_lib:
+	make -C ${INF_DIR}
 
 clean:
 	rm -f *.o

--- a/src/psykal/psy.f90
+++ b/src/psykal/psy.f90
@@ -3,23 +3,12 @@ module psy_mod
 implicit none
 !
 private
-public :: set_bounds
 public :: tracer_advection
 !
 integer :: jpi, jpj, jpk
 !
 contains
-  !
-  subroutine set_bounds(jpi_in,jpj_in,jpk_in)
-    !
-    integer, intent(in) :: jpi_in,jpj_in,jpk_in
-    !
-    jpi=jpi_in
-    jpj=jpj_in
-    jpk=jpk_in
-    !
-  end subroutine set_bounds
-  !
+
   subroutine tracer_advection(zind,tsn,ztfreez,rnfmsk,rnfmsk_z,upsmsk, &
                               zwx,zwy,mydomain,zslpx,zslpy,pun,pvn,pwn)
     ! Infrastructure modules
@@ -53,6 +42,11 @@ contains
     ! this to access grid-properties (such as masks) required by the
     ! kernels
     grid => tsn%grid
+
+    jpi = grid%simulation_domain%xstop
+    jpj = grid%simulation_domain%ystop
+    jpk = grid%nlevels
+    write (*,*) jpi, jpj, jpk
 
     DO jk = 1, jpk
       DO jj = 1, jpj

--- a/src/psykal/psy.f90
+++ b/src/psykal/psy.f90
@@ -21,8 +21,11 @@ contains
   end subroutine set_bounds
   !
   subroutine tracer_advection(zind,tsn,ztfreez,rnfmsk,rnfmsk_z,upsmsk, &
-       tmask,zwx,zwy,mydomain,umask,vmask,zslpx,zslpy,pun,pvn,pwn)
-    !
+                              zwx,zwy,mydomain,zslpx,zslpy,pun,pvn,pwn)
+    ! Infrastructure modules
+    use field_mod
+    use grid_mod
+    ! Kernel modules
     use zind_kern_mod, only : zind_kern
     use zwxy_kern_mod, only : zwxy_kern
     use zslpxy_kern_mod, only : zslpxy_kern
@@ -34,62 +37,69 @@ contains
     use zslpx_update_kern_mod, only : zslpx_update_kern
     use zwx2_kern_mod, only : zwx2_kern
     use mydomain_kern_mod, only : mydomain_kern
+    implicit none
     !
     ! RF all intent out's here are actually local to this call
-    real*8, intent(out) :: zind(jpi,jpj,jpk), zwx(jpi,jpj,jpk), &
-         zwy(jpi,jpj,jpk), zslpx(jpi,jpj,jpk), zslpy(jpi,jpj,jpk)
-    real*8, intent(in)  :: tsn(jpi,jpj,jpk), ztfreez(jpi,jpj), &
-         rnfmsk(jpi,jpj), rnfmsk_z(jpk), upsmsk(jpi,jpj), tmask(jpi,jpj,jpk), &
-         umask(jpi,jpj,jpk), vmask(jpi,jpj,jpk), pun(jpi,jpj,jpk), &
-         pvn(jpi,jpj,jpk), pwn(jpi,jpj,jpk)
-    real*8, intent(inout) :: mydomain(jpi,jpj,jpk)
+    type(r3d_field), intent(inout) :: zind, zwx, zwy, zslpx, zslpy
+    type(r3d_field), intent(in)    :: tsn, pun, pvn, pwn
+    type(r2d_field), intent(in)    :: rnfmsk, upsmsk, ztfreez
+    type(r1d_field), intent(in)    :: rnfmsk_z
+    type(r3d_field), intent(inout) :: mydomain
     ! local variables
     integer :: ji,jj,jk
+    type(grid_type), pointer :: grid
     !
+    ! Get a pointer to the grid from a read-only argument. We then use
+    ! this to access grid-properties (such as masks) required by the
+    ! kernels
+    grid => tsn%grid
+
     DO jk = 1, jpk
       DO jj = 1, jpj
         DO ji = 1, jpi
-          call zind_kern(zind,tsn,ztfreez,rnfmsk,rnfmsk_z,upsmsk,tmask,ji,jj,jk)
+          call zind_kern(zind%data, tsn%data, ztfreez%data, rnfmsk%data, &
+                         rnfmsk_z%data, upsmsk%data, grid%tmask, ji,jj,jk)
         END DO
       END DO
     END DO
     !
     DO jj=1,jpj
       DO ji=1,jpi
-        zwx(ji,jj,jpk) = 0.d0
+        zwx%data(ji,jj,jpk) = 0.d0
       END DO
     END DO
     !
     DO jj=1,jpj
       DO ji=1,jpi
-        zwy(ji,jj,jpk) = 0.d0
+        zwy%data(ji,jj,jpk) = 0.d0
       END DO
     END DO
     !
     DO jk = 1, jpk-1
       DO jj = 1, jpj-1
         DO ji = 1, jpi-1
-          call zwxy_kern(zwx,zwy,mydomain,umask,vmask,ji,jj,jk)
+          call zwxy_kern(zwx%data,zwy%data,mydomain%data, &
+                         grid%umask,grid%vmask,ji,jj,jk)
         END DO
       END DO
     END DO
     !
     DO jj=1,jpj
       DO ji=1,jpi
-        zslpx(ji,jj,jpk) = 0.d0
+        zslpx%data(ji,jj,jpk) = 0.d0
       END DO
     END DO
     !
     DO jj=1,jpj
       DO ji=1,jpi
-        zslpy(ji,jj,jpk) = 0.d0
+        zslpy%data(ji,jj,jpk) = 0.d0
       END DO
     END DO
     !
     DO jk = 1, jpk-1
       DO jj = 2, jpj
         DO ji = 2, jpi
-          call zslpxy_kern(zslpx,zslpy,zwx,zwy,ji,jj,jk)
+          call zslpxy_kern(zslpx%data,zslpy%data,zwx%data,zwy%data,ji,jj,jk)
         END DO
       END DO
     END DO
@@ -97,7 +107,7 @@ contains
     DO jk = 1, jpk-1
       DO jj = 2, jpj
         DO ji = 2, jpi
-          call zslpxy_update_kern(zslpx,zslpy,zwx,zwy,ji,jj,jk)
+          call zslpxy_update_kern(zslpx%data,zslpy%data,zwx%data,zwy%data,ji,jj,jk)
         END DO
       END DO
     END DO
@@ -105,7 +115,8 @@ contains
     DO jk = 1, jpk-1
       DO jj = 2, jpj-1
         DO ji = 2, jpi-1
-          call zwxy2_kern(zwx,zwy,pun,pvn,mydomain,zind,zslpx,zslpy,ji,jj,jk)
+          call zwxy2_kern(zwx%data,zwy%data,pun%data,pvn%data,mydomain%data, &
+                          zind%data,zslpx%data,zslpy%data,ji,jj,jk)
         END DO
       END DO
     END DO
@@ -113,41 +124,41 @@ contains
     DO jk = 1, jpk-1
       DO jj = 2, jpj-1
         DO ji = 2, jpi-1
-          call mydomain_update_kern(mydomain,zwx,zwy,ji,jj,jk)
+          call mydomain_update_kern(mydomain%data,zwx%data,zwy%data,ji,jj,jk)
         END DO
       END DO
     END DO
     !
     DO jj=1,jpj
       DO ji=1,jpi
-        zwx(ji,jj,1) = 0.d0
+        zwx%data(ji,jj,1) = 0.d0
       END DO
     END DO
     !
     DO jj=1,jpj
       DO ji=1,jpi
-        zwx(ji,jj,jpk) = 0.d0
+        zwx%data(ji,jj,jpk) = 0.d0
       END DO
     END DO
     !
     DO jk = 2, jpk-1
        DO jj = 1, jpj
           DO ji = 1, jpi
-             call zwx_kern(zwx,tmask,mydomain,ji,jj,jk)
+             call zwx_kern(zwx%data,grid%tmask,mydomain%data,ji,jj,jk)
           END DO
        END DO
     END DO
     !
     DO jj=1,jpj
       DO ji=1,jpi
-        zslpx(ji,jj,1) = 0.d0
+        zslpx%data(ji,jj,1) = 0.d0
       END DO
     END DO
     !
     DO jk = 2, jpk-1
       DO jj = 1, jpj
         DO ji = 1, jpi
-          call zslpx_kern(zslpx,zwx,ji,jj,jk)
+          call zslpx_kern(zslpx%data,zwx%data,ji,jj,jk)
         END DO
       END DO
     END DO
@@ -155,21 +166,22 @@ contains
     DO jk = 2, jpk-1     
       DO jj = 1, jpj
         DO ji = 1, jpi
-          call zslpx_update_kern(zslpx,zwx,ji,jj,jk)
+          call zslpx_update_kern(zslpx%data,zwx%data,ji,jj,jk)
         END DO
       END DO
     END DO
     !
     DO jj=1,jpj
       DO ji=1,jpi
-        zwx(ji,jj,1) = pwn(ji,jj,1) * mydomain(ji,jj,1)
+        zwx%data(ji,jj,1) = pwn%data(ji,jj,1) * mydomain%data(ji,jj,1)
       END DO
     END DO
     !
     DO jk = 2, jpk
       DO jj = 2, jpj-1
         DO ji = 2, jpi-1
-          call zwx2_kern(zwx,pwn,mydomain,zind,zslpx,ji,jj,jk)
+          call zwx2_kern(zwx%data,pwn%data,mydomain%data,zind%data, &
+                         zslpx%data,ji,jj,jk)
         END DO
       END DO
     END DO
@@ -177,7 +189,7 @@ contains
     DO jk = 1, jpk-1
       DO jj = 2, jpj-1     
         DO ji = 2, jpi-1
-          call mydomain_kern(mydomain,zwx,ji,jj,jk)
+          call mydomain_kern(mydomain%data,zwx%data,ji,jj,jk)
         END DO
       END DO
     END DO

--- a/src/psykal/psy.f90
+++ b/src/psykal/psy.f90
@@ -46,8 +46,8 @@ contains
     jpi = grid%simulation_domain%xstop
     jpj = grid%simulation_domain%ystop
     jpk = grid%nlevels
-    write (*,*) jpi, jpj, jpk
 
+    ! T points
     DO jk = 1, jpk
       DO jj = 1, jpj
         DO ji = 1, jpi
@@ -57,18 +57,21 @@ contains
       END DO
     END DO
     !
+    ! Zero whole of bottom layer
     DO jj=1,jpj
       DO ji=1,jpi
         zwx%data(ji,jj,jpk) = 0.d0
       END DO
     END DO
     !
+    ! Zero whole of bottom layer
     DO jj=1,jpj
       DO ji=1,jpi
         zwy%data(ji,jj,jpk) = 0.d0
       END DO
     END DO
     !
+    ! U and V points
     DO jk = 1, jpk-1
       DO jj = 1, jpj-1
         DO ji = 1, jpi-1
@@ -78,18 +81,21 @@ contains
       END DO
     END DO
     !
+    ! Zero whole of bottom layer
     DO jj=1,jpj
       DO ji=1,jpi
         zslpx%data(ji,jj,jpk) = 0.d0
       END DO
     END DO
     !
+    ! Zero whole of bottom layer
     DO jj=1,jpj
       DO ji=1,jpi
         zslpy%data(ji,jj,jpk) = 0.d0
       END DO
     END DO
     !
+    ! Compute slopes at T point
     DO jk = 1, jpk-1
       DO jj = 2, jpj
         DO ji = 2, jpi
@@ -98,6 +104,7 @@ contains
       END DO
     END DO
     !
+    ! Update slopes at T point
     DO jk = 1, jpk-1
       DO jj = 2, jpj
         DO ji = 2, jpi

--- a/src/psykal/tra_adv_alg.F90
+++ b/src/psykal/tra_adv_alg.F90
@@ -14,17 +14,25 @@ PROGRAM tra_adv
    !> Modules from the dl-esm-inf library
    USE kind_params_mod, only: wp
    USE grid_mod
+   USE field_mod
    implicit none
-   REAL*8, ALLOCATABLE, SAVE, DIMENSION(:,:,:,:) :: t3sn, t3ns, t3ew, t3we
-   REAL*8, ALLOCATABLE, SAVE, DIMENSION(:,:,:)   :: tsn 
-   REAL*8, ALLOCATABLE, SAVE, DIMENSION(:,:,:)   :: pun, pvn, pwn
-   REAL*8, ALLOCATABLE, SAVE, DIMENSION(:,:,:)   :: mydomain, zslpx, zslpy, zwx, zwy, umask, vmask, tmask, zind
-   REAL*8, ALLOCATABLE, SAVE, DIMENSION(:,:)     :: ztfreez, rnfmsk, upsmsk
-   REAL*8, ALLOCATABLE, SAVE, DIMENSION(:)       :: rnfmsk_z
+   REAL*8, ALLOCATABLE, SAVE, DIMENSION(:,:,:) :: tmask_input
+   !> 'Now' ocean temperature/salinity (in NEMO this is a 4D array with the fourth
+   !! dimension holding the tracer index)
+   type(r3d_field) :: tsn 
+   !REAL*8, ALLOCATABLE, SAVE, DIMENSION(:,:,:)   :: tsn 
+   !> Three ocean velocity components
+   type(r3d_field) :: pun, pvn, pwn
+   !REAL*8, ALLOCATABLE, SAVE, DIMENSION(:,:,:)   :: pun, pvn, pwn
+   type(r3d_field) :: mydomain, zslpx, zslpy, zwx, zwy, zind
+   !REAL*8, ALLOCATABLE, SAVE, DIMENSION(:,:,:) :: mydomain, zslpx, zslpy, zwx, zwy, umask, vmask, tmask, zind
+   type(r2d_field) :: ztfreez, rnfmsk, upsmsk
+   !REAL*8, ALLOCATABLE, SAVE, DIMENSION(:,:) :: ztfreez, rnfmsk, upsmsk
+   type(r1d_field) :: rnfmsk_z
+   !REAL*8, ALLOCATABLE, SAVE, DIMENSION(:) :: rnfmsk_z
    REAL*8                                        :: zice, zu, z0u, zzwx, zv, z0v, zzwy, ztra, zalpha
-   REAL*8                                        :: r
    REAL*8                                        :: zw, z0w
-   INTEGER                                       :: jpi, jpj, jpk, ji, jj, jk, jt
+   INTEGER                                       :: jpi, jpj, jpk, jt
    INTEGER*8                                     :: it
    CHARACTER(len=10)                             :: env
    !> Timer indexes, one for initialisation, one for the 'time-stepping'
@@ -53,25 +61,6 @@ PROGRAM tra_adv
 
    call timer_start(init_timer)
 
-   ALLOCATE( mydomain (jpi,jpj,jpk))
-   ALLOCATE( zwx (jpi,jpj,jpk))
-   ALLOCATE( zwy (jpi,jpj,jpk))
-   ALLOCATE( zslpx (jpi,jpj,jpk))
-   ALLOCATE( zslpy (jpi,jpj,jpk))
-   ALLOCATE( pun (jpi,jpj,jpk))
-   ALLOCATE( pvn (jpi,jpj,jpk))
-   ALLOCATE( pwn (jpi,jpj,jpk))
-   ALLOCATE( umask (jpi,jpj,jpk))
-   ALLOCATE( vmask (jpi,jpj,jpk))
-   ALLOCATE( tmask (jpi,jpj,jpk))
-   ALLOCATE( zind (jpi,jpj,jpk))
-   ALLOCATE( ztfreez (jpi,jpj))
-   ALLOCATE( rnfmsk (jpi,jpj))
-   ALLOCATE( upsmsk (jpi,jpj))
-   ALLOCATE( rnfmsk_z (jpk))
-   ALLOCATE( tsn(jpi,jpj,jpk))
-
-
    ! Create the model grid. We use a NE offset (i.e. the U, V and F
    ! points immediately to the North and East of a T point all have the
    ! same i,j index).  This is the same offset scheme as used by NEMO.
@@ -80,47 +69,38 @@ PROGRAM tra_adv
                           (/BC_EXTERNAL,BC_EXTERNAL,BC_NONE/), &
                           OFFSET_NE)
 
-   tmask(:,:,:) = 1.0d0 ! all inner cells
+   ! Generate our 'input' T mask
+   allocate(tmask_input(jpi,jpj,jpk))
+   tmask_input(:,:,:) = 1.0d0 ! all inner cells
 
    ! Having specified the T points mask, we can set up mesh parameters
-   call grid_init(model_grid, jpi, jpj, jpk, dx, dy, dz, tmask)
+   call grid_init(model_grid, jpi, jpj, jpk, dx, dy, dz, tmask_input)
 
-   ! arrays initialization
+   !> Example tracer field (e.g. temperature or salinity)
+   tsn = r3d_field(model_grid, T_POINTS)
+   mydomain = r3d_field(model_grid, T_POINTS)
+   !> \todo Check that I've got the grid-point types right for these
+   zwx = r3d_field(model_grid, U_POINTS)
+   zwy = r3d_field(model_grid, V_POINTS)
+   zslpx = r3d_field(model_grid, U_POINTS)
+   zslpy = r3d_field(model_grid, V_POINTS)
+   !> Ocean velocity components
+   pun = r3d_field(model_grid, U_POINTS)
+   pvn = r3d_field(model_grid, V_POINTS)
+   !> \todo Where do vertical components live on the grid?
+   pwn = r3d_field(model_grid, T_POINTS)
+   !> \todo This is a workspace array; I don't yet know to what it corresponds
+   zind = r3d_field(model_grid, T_POINTS)
+   !> River mouth runoff mask (horiz)
+   rnfmsk = r2d_field(model_grid, T_POINTS)
+   !> River mouth runoff mask (vert)
+   rnfmsk_z = r1d_field(model_grid)
+   !> \todo Work out what these three fields represent
+   ztfreez = r2d_field(model_grid, T_POINTS)
+   upsmsk = r2d_field(model_grid, T_POINTS)
+   tsn = r3d_field(model_grid, T_POINTS)
 
-   r = jpi*jpj*jpk
-
-   ! the following three lines can be uncommented to randomize arrays initialization
-   !call random_seed()
-   !call random_number(r)
-   !r = r*jpi*jpj*jpk
-
-   DO jk = 1, jpk
-      DO jj = 1, jpj
-          DO ji = 1, jpi
-              umask(ji,jj,jk) = ji*jj*jk/r
-              mydomain(ji,jj,jk) =ji*jj*jk/r
-              pun(ji,jj,jk) =ji*jj*jk/r
-              pvn(ji,jj,jk) =ji*jj*jk/r
-              pwn(ji,jj,jk) =ji*jj*jk/r
-              vmask(ji,jj,jk)= ji*jj*jk/r
-              tsn(ji,jj,jk)= ji*jj*jk/r
-              tmask(ji,jj,jk)= ji*jj*jk/r
-          END DO
-      END DO
-   END DO
-
-   r = jpi*jpj
-   DO jj=1, jpj
-      DO ji=1, jpi
-         ztfreez(ji,jj) = ji*jj/r
-         upsmsk(ji,jj) = ji*jj/r
-         rnfmsk(ji,jj) = ji*jj/r
-      END DO
-   END DO
-
-   DO jk=1, jpk
-      rnfmsk_z(jk)=jk/jpk
-   END DO
+   call init_fields()
 
    call timer_stop(init_timer)
 
@@ -158,36 +138,67 @@ PROGRAM tra_adv
 
   call timer_stop(step_timer)
 
-  OPEN(unit = 4, file = 'output.dat', form='formatted')
-  
-  DO jk = 1, jpk-1
-     DO jj = 2, jpj-1
-        DO ji = 2, jpi-1
-           write(4,*) mydomain(ji,jj,jk)
-        END DO
-     END DO
-  END DO
-
-  CLOSE(4)
-
-  DEALLOCATE( mydomain )
-  DEALLOCATE( zwx )
-  DEALLOCATE( zwy )
-  DEALLOCATE( zslpx )
-  DEALLOCATE( zslpy )
-  DEALLOCATE( pun )
-  DEALLOCATE( pvn )
-  DEALLOCATE( pwn )
-  DEALLOCATE( umask)
-  DEALLOCATE( vmask)
-  DEALLOCATE( tmask)
-  DEALLOCATE( zind )
-  DEALLOCATE( ztfreez )
-  DEALLOCATE( rnfmsk)
-  DEALLOCATE( upsmsk)
-  DEALLOCATE( rnfmsk_z)
-  DEALLOCATE( tsn)
+  call write_field(mydomain)
 
   CALL timer_report()
+
+CONTAINS
+
+  subroutine init_fields()
+    REAL(wp) :: r
+    integer :: ji, jj, jk
+
+    ! Array initialization
+    r = jpi*jpj*jpk
+
+    ! the following three lines can be uncommented to randomize the array
+    ! initialization
+    !call random_seed()
+    !call random_number(r)
+    !r = r*jpi*jpj*jpk
+
+   DO jk = 1, jpk
+      DO jj = 1, jpj
+          DO ji = 1, jpi
+              mydomain%data(ji,jj,jk) =ji*jj*jk/r
+              pun%data(ji,jj,jk) =ji*jj*jk/r
+              pvn%data(ji,jj,jk) =ji*jj*jk/r
+              pwn%data(ji,jj,jk) =ji*jj*jk/r
+              tsn%data(ji,jj,jk)= ji*jj*jk/r
+          END DO
+      END DO
+   END DO
+
+   r = jpi*jpj
+   DO jj=1, jpj
+      DO ji=1, jpi
+         ztfreez%data(ji,jj) = ji*jj/r
+         upsmsk%data(ji,jj) = ji*jj/r
+         rnfmsk%data(ji,jj) = ji*jj/r
+      END DO
+   END DO
+
+   DO jk=1, jpk
+      rnfmsk_z%data(jk)=jk/jpk
+   END DO
+
+  end subroutine init_fields
+
+  subroutine write_field(mydomain)
+    type(r3d_field), intent(in) :: mydomain
+    integer :: ji, jj, jk
+
+    OPEN(unit = 24, file = 'output.dat', form='formatted')
+  
+    DO jk = 1, jpk-1
+       DO jj = 2, jpj-1
+          DO ji = 2, jpi-1
+             write(24,*) mydomain%data(ji,jj,jk)
+          END DO
+       END DO
+    END DO
+
+    CLOSE(24)
+  end subroutine write_field
 
 END PROGRAM tra_adv

--- a/src/psykal/tra_adv_alg.F90
+++ b/src/psykal/tra_adv_alg.F90
@@ -112,7 +112,7 @@ PROGRAM tra_adv
    DO jt = 1, it
 
       call tracer_advection(zind,tsn,ztfreez,rnfmsk,rnfmsk_z,upsmsk, &
-           tmask,zwx,zwy,mydomain,umask,vmask,zslpx,zslpy,pun,pvn,pwn)
+                            zwx,zwy,mydomain,zslpx,zslpy,pun,pvn,pwn)
 
       !PSyclone ... this is what the algorithm code would look like
       !call invoke (

--- a/src/psykal/tra_adv_alg.F90
+++ b/src/psykal/tra_adv_alg.F90
@@ -84,8 +84,9 @@ PROGRAM tra_adv
    mydomain = r3d_field(model_grid, T_POINTS)
    zwx = r3d_field(model_grid, U_POINTS)
    zwy = r3d_field(model_grid, V_POINTS)
-   zslpx = r3d_field(model_grid, U_POINTS)
-   zslpy = r3d_field(model_grid, V_POINTS)
+   ! Slopes of the above fields, evaluated at T points
+   zslpx = r3d_field(model_grid, T_POINTS)
+   zslpy = r3d_field(model_grid, T_POINTS)
    !> Ocean velocity components
    pun = r3d_field(model_grid, U_POINTS)
    pvn = r3d_field(model_grid, V_POINTS)
@@ -102,9 +103,7 @@ PROGRAM tra_adv
    upsmsk = r2d_field(model_grid, T_POINTS)
    tsn = r3d_field(model_grid, T_POINTS)
 
-   ! Pass the dimensions of the *internal* region to the initialisation
-   ! routine so that we get the same values as used in the original
-   ! version of the kernel.
+   ! Populate these fields with values
    call init_fields()
 
    call timer_stop(init_timer)
@@ -121,10 +120,10 @@ PROGRAM tra_adv
 
       !PSyclone ... this is what the algorithm code would look like
       !call invoke (
-      !  zind_kern(zind,tsn,ztfreez,rnfmsk,rnfmsk_z,upsmsk,tmask),
+      !  zind_kern(zind,tsn,ztfreez,rnfmsk,rnfmsk_z,upsmsk),
       !  zero_bottom_layer(zwx),
       !  zero_bottom_layer(zwy),
-      !  zwxy_kern(zwx,zwy,mydomain,umask,vmask),
+      !  zwxy_kern(zwx,zwy,mydomain),
       !  zero_bottom_layer(zslpx),
       !  zero_bottom_layer(zslpy),
       !  zslpxy_kern(zslpx,zslpy,zwx,zwy),
@@ -133,7 +132,7 @@ PROGRAM tra_adv
       !  mydomain_update_kern(mydomain,zwx,zwy),
       !  zero_top_layer(zwx),
       !  zero_bottom_layer(zwx),
-      !  zwx_kern(zwx,tmask,mydomain),
+      !  zwx_kern(zwx,mydomain),
       !  zero_top_layer(zslpx),
       !  zslpx_kern(zslpx,zwx),
       !  zslpx_update_kern(zslpx,zwx),

--- a/src/psykal/tra_adv_alg.F90
+++ b/src/psykal/tra_adv_alg.F90
@@ -11,7 +11,7 @@ PROGRAM tra_adv
    USE grid_mod
    USE field_mod
    !PSyclone ... we would declare the links to the Kernel metadata here
-   USE psy_mod, only : tracer_advection, set_bounds
+   USE psy_mod, only : tracer_advection
    implicit none
    REAL*8, ALLOCATABLE, SAVE, DIMENSION(:,:,:) :: tmask_input
    !> 'Now' ocean temperature/salinity (in NEMO this is a 4D array with the fourth
@@ -100,9 +100,6 @@ PROGRAM tra_adv
    call init_fields()
 
    call timer_stop(init_timer)
-
-   ! temporary way to provide dimension information to PSy layer
-   call set_bounds(jpi,jpj,jpk)
 
 !***********************
 !* Start of the symphony


### PR DESCRIPTION
Move one-step closer to code that would be generated using PSyclone by making the code use the dl-esm-inf infrastructure for fields and the grid. This means moving away from arrays and using field objects instead.