### PR TITLE
Add metadata

### DIFF
--- a/src/psykal/mydomain_kern.f90
+++ b/src/psykal/mydomain_kern.f90
@@ -2,6 +2,16 @@ module mydomain_kern_mod
 !
 implicit none
 !
+type, extends(kernel_type) :: mydomain_type
+  type(arg), dimension(2) :: meta_args = (/ &
+    arg(WRITE, 3D, CT), &
+    arg(READ,  3D, CU, STENCIL(U)) /)
+  integer :: ITERATES_OVER = 3D
+  integer :: INDEX_OFFSET = OFFSET_NE
+contains
+  procedure, nopass :: code => mydomain_kern
+end type mydomain_type
+!        
 contains
   !
   subroutine mydomain_kern(mydomain,zwx,ji,jj,jk)

--- a/src/psykal/mydomain_kern.f90
+++ b/src/psykal/mydomain_kern.f90
@@ -1,26 +1,28 @@
 module mydomain_kern_mod
 !
+use kind_params_mod, only : wp
+!
 implicit none
 !
-type, extends(kernel_type) :: mydomain_type
-  type(arg), dimension(2) :: meta_args = (/ &
-    arg(WRITE, 3D, CT), &
-    arg(READ,  3D, CU, STENCIL(U)) /)
-  integer :: ITERATES_OVER = 3D
-  integer :: INDEX_OFFSET = OFFSET_NE
-contains
-  procedure, nopass :: code => mydomain_kern
-end type mydomain_type
+!type, extends(kernel_type) :: mydomain_type
+!  type(arg), dimension(2) :: meta_args = (/ &
+!    arg(WRITE, DIMS(3), CT), &
+!    arg(READ,  DIMS(3), CU, STENCIL(U)) /)
+!  integer :: ITERATES_OVER = DIMS(3)
+!  integer :: INDEX_OFFSET = OFFSET_NE
+!contains
+!  procedure, nopass :: code => mydomain_kern
+!end type mydomain_type
 !        
 contains
   !
   subroutine mydomain_kern(mydomain,zwx,ji,jj,jk)
     !
-    real*8, intent(out) :: mydomain(:,:,:)
-    real*8, intent(in)  :: zwx(:,:,:)
+    real(wp), intent(out) :: mydomain(:,:,:)
+    real(wp), intent(in)  :: zwx(:,:,:)
     integer, intent(in) :: ji,jj,jk
     ! local variables
-    real*8 :: ztra, zbtr
+    real(wp) :: ztra, zbtr
     !
     zbtr = 1.d0
     ztra = - zbtr * ( zwx(ji,jj,jk) - zwx(ji,jj,jk+1) )

--- a/src/psykal/mydomain_update_kern.f90
+++ b/src/psykal/mydomain_update_kern.f90
@@ -1,27 +1,29 @@
 module mydomain_update_kern_mod
 !
+use kind_params_mod, only : wp
+!
 implicit none
 !
-type, extends(kernel_type) :: mydomain_update_type
-  type(arg), dimension(3) :: meta_args = (/ &
-    arg(WRITE, 3D, CT), &
-    arg(READ,  3D, CU, STENCIL(W)), &
-    arg(READ,  3D, CV, STENCIL(S)) /)
-  integer :: ITERATES_OVER = 3D
-  integer :: INDEX_OFFSET = OFFSET_NE
-contains
-  procedure, nopass :: code => mydomain_update_kern
-end type mydomain_update_type
+!type, extends(kernel_type) :: mydomain_update_type
+!  type(arg), dimension(3) :: meta_args = (/ &
+!    arg(WRITE, DIMS(3), CT), &
+!    arg(READ,  DIMS(3), CU, STENCIL(W)), &
+!    arg(READ,  DIMS(3), CV, STENCIL(S)) /)
+!  integer :: ITERATES_OVER = DIMS(3)
+!  integer :: INDEX_OFFSET = OFFSET_NE
+!contains
+!  procedure, nopass :: code => mydomain_update_kern
+!end type mydomain_update_type
 !
 contains
   !
   subroutine mydomain_update_kern(mydomain,zwx,zwy,ji,jj,jk)
     !
-    real*8,  intent(inout) :: mydomain(:,:,:)
-    real*8,  intent(in)  :: zwx(:,:,:), zwy(:,:,:)
+    real(wp),  intent(inout) :: mydomain(:,:,:)
+    real(wp),  intent(in)  :: zwx(:,:,:), zwy(:,:,:)
     integer, intent(in) :: ji,jj,jk
     ! local variables
-    real*8 :: zbtr,ztra
+    real(wp) :: zbtr,ztra
     !
     zbtr = 1.d0
     ztra = - zbtr * ( zwx(ji,jj,jk) - zwx(ji-1,jj  ,jk  )   &

--- a/src/psykal/mydomain_update_kern.f90
+++ b/src/psykal/mydomain_update_kern.f90
@@ -2,6 +2,17 @@ module mydomain_update_kern_mod
 !
 implicit none
 !
+type, extends(kernel_type) :: mydomain_update_type
+  type(arg), dimension(3) :: meta_args = (/ &
+    arg(WRITE, 3D, CT), &
+    arg(READ,  3D, CU, STENCIL(W)), &
+    arg(READ,  3D, CV, STENCIL(S)) /)
+  integer :: ITERATES_OVER = 3D
+  integer :: INDEX_OFFSET = OFFSET_NE
+contains
+  procedure, nopass :: code => mydomain_update_kern
+end type mydomain_update_type
+!
 contains
   !
   subroutine mydomain_update_kern(mydomain,zwx,zwy,ji,jj,jk)

--- a/src/psykal/zind_kern.f90
+++ b/src/psykal/zind_kern.f90
@@ -1,33 +1,35 @@
 module zind_kern_mod
 !
+use kind_params_mod, only : wp
+!
 implicit none
 !
-type, extends(kernel_type) :: zind_type
-  type(arg), dimension(7) :: meta_args = (/ &
-    arg(WRITE, 3D, CT), &
-    arg(READ,  3D, CT), &
-    arg(READ,  2D, CT), &
-    arg(READ,  2D, CT), &
-    arg(READ,  1D    ), &
-    arg(READ,  2D, CT), &
-    arg(READ,  TMASK_3D) /)
-  integer :: ITERATES_OVER = 3D
-  integer :: INDEX_OFFSET = OFFSET_NE
-contains
-  procedure, nopass :: code => zind_kern
-end type zind_type
+!type, extends(kernel_type) :: zind_type
+!  type(arg), dimension(7) :: meta_args = (/ &
+!    arg(WRITE, DIMS(3), CT), &
+!    arg(READ,  DIMS(3), CT), &
+!    arg(READ,  DIMS(2), CT), &
+!    arg(READ,  DIMS(2), CT), &
+!    arg(READ,  DIMS(1)    ), &
+!    arg(READ,  DIMS(2), CT), &
+!    arg(READ,  GRID_MASK_T_3D) /)
+!  integer :: ITERATES_OVER = DIMS(3)
+!  integer :: INDEX_OFFSET = OFFSET_NE
+!contains
+!  procedure, nopass :: code => zind_kern
+!end type zind_type
 !        
 contains
   !
   subroutine zind_kern(zind,tsn,ztfreez,rnfmsk,rnfmsk_z,upsmsk,tmask,ji,jj,jk)
     !
-    real*8,  intent(out) :: zind(:,:,:)
-    real*8,  intent(in)  :: tsn(:,:,:)
-    real*8,  intent(in)  :: tmask(:,:,:)
-    real*8,  intent(in)  :: ztfreez(:,:), rnfmsk(:,:), rnfmsk_z(:), upsmsk(:,:)
+    real(wp),  intent(out) :: zind(:,:,:)
+    real(wp),  intent(in)  :: tsn(:,:,:)
+    real(wp),  intent(in)  :: tmask(:,:,:)
+    real(wp),  intent(in)  :: ztfreez(:,:), rnfmsk(:,:), rnfmsk_z(:), upsmsk(:,:)
     integer, intent(in) :: ji,jj,jk
     ! local variables
-    real*8 :: zice
+    real(wp) :: zice
     !
     IF( tsn(ji,jj,jk) <= ztfreez(ji,jj) + 0.1d0 ) THEN   ;   zice = 1.d0
     ELSE                                                 ;   zice = 0.d0

--- a/src/psykal/zind_kern.f90
+++ b/src/psykal/zind_kern.f90
@@ -2,6 +2,21 @@ module zind_kern_mod
 !
 implicit none
 !
+type, extends(kernel_type) :: zind_type
+  type(arg), dimension(7) :: meta_args = (/ &
+    arg(WRITE, 3D, CT), &
+    arg(READ,  3D, CT), &
+    arg(READ,  2D, CT), &
+    arg(READ,  2D, CT), &
+    arg(READ,  1D    ), &
+    arg(READ,  2D, CT), &
+    arg(READ,  TMASK_3D) /)
+  integer :: ITERATES_OVER = 3D
+  integer :: INDEX_OFFSET = OFFSET_NE
+contains
+  procedure, nopass :: code => zind_kern
+end type zind_type
+!        
 contains
   !
   subroutine zind_kern(zind,tsn,ztfreez,rnfmsk,rnfmsk_z,upsmsk,tmask,ji,jj,jk)

--- a/src/psykal/zslpx_kern.f90
+++ b/src/psykal/zslpx_kern.f90
@@ -2,6 +2,16 @@ module zslpx_kern_mod
 !
 implicit none
 !
+type, extends(kernel_type) :: zslpx_type
+  type(arg), dimension(2) :: meta_args = (/ &
+    arg(WRITE, 3D, CU), &
+    arg(READ,  3D, CU, STENCIL(U)) /)
+  integer :: ITERATES_OVER = 3D
+  integer :: INDEX_OFFSET = OFFSET_NE
+contains
+  procedure, nopass :: code => zslpx_kern
+end type zslpx_type
+!        
 contains
   !
   subroutine zslpx_kern(zslpx,zwx,ji,jj,jk)

--- a/src/psykal/zslpx_kern.f90
+++ b/src/psykal/zslpx_kern.f90
@@ -1,23 +1,25 @@
 module zslpx_kern_mod
 !
+use kind_params_mod, only : wp
+!
 implicit none
 !
-type, extends(kernel_type) :: zslpx_type
-  type(arg), dimension(2) :: meta_args = (/ &
-    arg(WRITE, 3D, CU), &
-    arg(READ,  3D, CU, STENCIL(U)) /)
-  integer :: ITERATES_OVER = 3D
-  integer :: INDEX_OFFSET = OFFSET_NE
-contains
-  procedure, nopass :: code => zslpx_kern
-end type zslpx_type
+!type, extends(kernel_type) :: zslpx_type
+!  type(arg), dimension(2) :: meta_args = (/ &
+!    arg(WRITE, DIMS(3), CU), &
+!    arg(READ,  DIMS(3), CU, STENCIL(U)) /)
+!  integer :: ITERATES_OVER = DIMS(3)
+!  integer :: INDEX_OFFSET = OFFSET_NE
+!contains
+!  procedure, nopass :: code => zslpx_kern
+!end type zslpx_type
 !        
 contains
   !
   subroutine zslpx_kern(zslpx,zwx,ji,jj,jk)
     !
-    real*8, intent(out) :: zslpx(:,:,:)
-    real*8, intent(in)  :: zwx(:,:,:)
+    real(wp), intent(out) :: zslpx(:,:,:)
+    real(wp), intent(in)  :: zwx(:,:,:)
     integer, intent(in) :: ji,jj,jk
     !
     zslpx(ji,jj,jk) =                    ( zwx(ji,jj,jk) + zwx(ji,jj,jk+1) )   &

--- a/src/psykal/zslpx_update_kern.f90
+++ b/src/psykal/zslpx_update_kern.f90
@@ -1,23 +1,25 @@
 module zslpx_update_kern_mod
 !
+use kind_params_mod, only : wp
+!
 implicit none
 !
-type, extends(kernel_type) :: zslpx_update_type
-  type(arg), dimension(2) :: meta_args = (/ &
-    arg(READWRITE, 3D, CU), &
-    arg(READ,      3D, CU, STENCIL(U)) /)
-  integer :: ITERATES_OVER = 3D
-  integer :: INDEX_OFFSET = OFFSET_NE
-contains
-  procedure, nopass :: code => zslpx_update_kern
-end type zslpx_update_type
+!type, extends(kernel_type) :: zslpx_update_type
+!  type(arg), dimension(2) :: meta_args = (/ &
+!    arg(READWRITE, DIMS(3), CU), &
+!    arg(READ,      DIMS(3), CU, STENCIL(U)) /)
+!  integer :: ITERATES_OVER = DIMS(3)
+!  integer :: INDEX_OFFSET = OFFSET_NE
+!contains
+!  procedure, nopass :: code => zslpx_update_kern
+!end type zslpx_update_type
 !        
 contains
   !
   subroutine zslpx_update_kern(zslpx,zwx,ji,jj,jk)
     !
-    real*8, intent(inout) :: zslpx(:,:,:)
-    real*8, intent(in)  :: zwx(:,:,:)
+    real(wp), intent(inout) :: zslpx(:,:,:)
+    real(wp), intent(in)  :: zwx(:,:,:)
     integer, intent(in) :: ji,jj,jk
     !
     zslpx(ji,jj,jk) = SIGN( 1.d0, zslpx(ji,jj,jk) ) * MIN( ABS( zslpx(ji,jj,jk  ) ), &

--- a/src/psykal/zslpx_update_kern.f90
+++ b/src/psykal/zslpx_update_kern.f90
@@ -2,6 +2,16 @@ module zslpx_update_kern_mod
 !
 implicit none
 !
+type, extends(kernel_type) :: zslpx_update_type
+  type(arg), dimension(2) :: meta_args = (/ &
+    arg(READWRITE, 3D, CU), &
+    arg(READ,      3D, CU, STENCIL(U)) /)
+  integer :: ITERATES_OVER = 3D
+  integer :: INDEX_OFFSET = OFFSET_NE
+contains
+  procedure, nopass :: code => zslpx_update_kern
+end type zslpx_update_type
+!        
 contains
   !
   subroutine zslpx_update_kern(zslpx,zwx,ji,jj,jk)

--- a/src/psykal/zslpxy_kern.f90
+++ b/src/psykal/zslpxy_kern.f90
@@ -2,6 +2,18 @@ module zslpxy_kern_mod
 !
 implicit none
 !
+type, extends(kernel_type) :: zslpxy_type
+  type(arg), dimension(4) :: meta_args = (/ &
+    arg(WRITE, 3D, CU), &
+    arg(WRITE, 3D, CV), &
+    arg(READ,  3D, CU, STENCIL(W)), &
+    arg(READ,  3D, CV, STENCIL(S)) /)
+  integer :: ITERATES_OVER = 3D
+  integer :: INDEX_OFFSET = OFFSET_NE
+contains
+  procedure, nopass :: code => zslpxy_kern
+end type zslpxy_type
+!
 contains
   !
   subroutine zslpxy_kern(zslpx,zslpy,zwx,zwy,ji,jj,jk)

--- a/src/psykal/zslpxy_kern.f90
+++ b/src/psykal/zslpxy_kern.f90
@@ -1,25 +1,27 @@
 module zslpxy_kern_mod
 !
+use kind_params_mod, only : wp
+!
 implicit none
 !
-type, extends(kernel_type) :: zslpxy_type
-  type(arg), dimension(4) :: meta_args = (/ &
-    arg(WRITE, 3D, CU), &
-    arg(WRITE, 3D, CV), &
-    arg(READ,  3D, CU, STENCIL(W)), &
-    arg(READ,  3D, CV, STENCIL(S)) /)
-  integer :: ITERATES_OVER = 3D
-  integer :: INDEX_OFFSET = OFFSET_NE
-contains
-  procedure, nopass :: code => zslpxy_kern
-end type zslpxy_type
+!type, extends(kernel_type) :: zslpxy_type
+!  type(arg), dimension(4) :: meta_args = (/ &
+!    arg(WRITE, DIMS(3), CU), &
+!    arg(WRITE, DIMS(3), CV), &
+!    arg(READ,  DIMS(3), CU, STENCIL(W)), &
+!    arg(READ,  DIMS(3), CV, STENCIL(S)) /)
+!  integer :: ITERATES_OVER = DIMS(3)
+!  integer :: INDEX_OFFSET = OFFSET_NE
+!contains
+!  procedure, nopass :: code => zslpxy_kern
+!end type zslpxy_type
 !
 contains
   !
   subroutine zslpxy_kern(zslpx,zslpy,zwx,zwy,ji,jj,jk)
     !
-    real*8, intent(out) :: zslpx(:,:,:), zslpy(:,:,:)
-    real*8, intent(in)  :: zwx(:,:,:), zwy(:,:,:)
+    real(wp), intent(out) :: zslpx(:,:,:), zslpy(:,:,:)
+    real(wp), intent(in)  :: zwx(:,:,:), zwy(:,:,:)
     integer, intent(in) :: ji,jj,jk
     !
     zslpx(ji,jj,jk) =                    ( zwx(ji,jj,jk) + zwx(ji-1,jj  ,jk) )   &

--- a/src/psykal/zslpxy_update_kern.f90
+++ b/src/psykal/zslpxy_update_kern.f90
@@ -2,6 +2,18 @@ module zslpxy_update_kern_mod
 !
 implicit none
 !
+type, extends(kernel_type) :: zslpxy_update_type
+  type(arg), dimension(4) :: meta_args = (/ &
+    arg(READWRITE, 3D, CU), &
+    arg(READWRITE, 3D, CV), &
+    arg(READ,      3D, CU, STENCIL(W)), &
+    arg(READ,      3D, CV, STENCIL(S)) /)
+  integer :: ITERATES_OVER = 3D
+  integer :: INDEX_OFFSET = OFFSET_NE
+contains
+  procedure, nopass :: code => zslpxy_update_kern
+end type zslpxy_update_type
+!
 contains
   !
   subroutine zslpxy_update_kern(zslpx,zslpy,zwx,zwy,ji,jj,jk)

--- a/src/psykal/zslpxy_update_kern.f90
+++ b/src/psykal/zslpxy_update_kern.f90
@@ -1,25 +1,27 @@
 module zslpxy_update_kern_mod
 !
+use kind_params_mod, only : wp
+!
 implicit none
 !
-type, extends(kernel_type) :: zslpxy_update_type
-  type(arg), dimension(4) :: meta_args = (/ &
-    arg(READWRITE, 3D, CU), &
-    arg(READWRITE, 3D, CV), &
-    arg(READ,      3D, CU, STENCIL(W)), &
-    arg(READ,      3D, CV, STENCIL(S)) /)
-  integer :: ITERATES_OVER = 3D
-  integer :: INDEX_OFFSET = OFFSET_NE
-contains
-  procedure, nopass :: code => zslpxy_update_kern
-end type zslpxy_update_type
+!type, extends(kernel_type) :: zslpxy_update_type
+!  type(arg), dimension(4) :: meta_args = (/ &
+!    arg(READWRITE, DIMS(3), CU), &
+!    arg(READWRITE, DIMS(3), CV), &
+!    arg(READ,      DIMS(3), CU, STENCIL(W)), &
+!    arg(READ,      DIMS(3), CV, STENCIL(S)) /)
+!  integer :: ITERATES_OVER = DIMS(3)
+!  integer :: INDEX_OFFSET = OFFSET_NE
+!contains
+!  procedure, nopass :: code => zslpxy_update_kern
+!end type zslpxy_update_type
 !
 contains
   !
   subroutine zslpxy_update_kern(zslpx,zslpy,zwx,zwy,ji,jj,jk)
     !
-    real*8, intent(inout) :: zslpx(:,:,:), zslpy(:,:,:)
-    real*8, intent(in)  :: zwx(:,:,:), zwy(:,:,:)
+    real(wp), intent(inout) :: zslpx(:,:,:), zslpy(:,:,:)
+    real(wp), intent(in)  :: zwx(:,:,:), zwy(:,:,:)
     integer, intent(in) :: ji,jj,jk
     !
     zslpx(ji,jj,jk) = SIGN( 1.d0, zslpx(ji,jj,jk) ) * MIN(    ABS( zslpx(ji  ,jj,jk) ),   &

--- a/src/psykal/zwx2_kern.f90
+++ b/src/psykal/zwx2_kern.f90
@@ -2,6 +2,19 @@ module zwx2_kern_mod
 !
 implicit none
 !
+type, extends(kernel_type) :: zslpx_type
+  type(arg), dimension(5) :: meta_args = (/ &
+    arg(WRITE, 3D, CU), &
+    arg(READ,  3D, CT), &
+    arg(READ,  3D, CT, STENCIL(D)), &
+    arg(READ,  3D, CT, STENCIL(D)), &
+    arg(READ,  3D, CU, STENCIL(D)) /)
+  integer :: ITERATES_OVER = 3D
+  integer :: INDEX_OFFSET = OFFSET_NE
+contains
+  procedure, nopass :: code => zslpx_kern
+end type zslpx_type
+!        
 contains
   !
   subroutine zwx2_kern(zwx,pwn,mydomain,zind,zslpx,ji,jj,jk)

--- a/src/psykal/zwx2_kern.f90
+++ b/src/psykal/zwx2_kern.f90
@@ -1,29 +1,31 @@
 module zwx2_kern_mod
 !
+use kind_params_mod, only : wp
+!
 implicit none
 !
-type, extends(kernel_type) :: zslpx_type
-  type(arg), dimension(5) :: meta_args = (/ &
-    arg(WRITE, 3D, CU), &
-    arg(READ,  3D, CT), &
-    arg(READ,  3D, CT, STENCIL(D)), &
-    arg(READ,  3D, CT, STENCIL(D)), &
-    arg(READ,  3D, CU, STENCIL(D)) /)
-  integer :: ITERATES_OVER = 3D
-  integer :: INDEX_OFFSET = OFFSET_NE
-contains
-  procedure, nopass :: code => zslpx_kern
-end type zslpx_type
+!type, extends(kernel_type) :: zslpx_type
+!  type(arg), dimension(5) :: meta_args = (/ &
+!    arg(WRITE, DIMS(3), CU), &
+!    arg(READ,  DIMS(3), CT), &
+!    arg(READ,  DIMS(3), CT, STENCIL(D)), &
+!    arg(READ,  DIMS(3), CT, STENCIL(D)), &
+!    arg(READ,  DIMS(3), CU, STENCIL(D)) /)
+!  integer :: ITERATES_OVER = DIMS(3)
+!  integer :: INDEX_OFFSET = OFFSET_NE
+!contains
+!  procedure, nopass :: code => zslpx_kern
+!end type zslpx_type
 !        
 contains
   !
   subroutine zwx2_kern(zwx,pwn,mydomain,zind,zslpx,ji,jj,jk)
     !
-    real*8, intent(out) :: zwx(:,:,:)
-    real*8, intent(in) :: pwn(:,:,:), mydomain(:,:,:), zind(:,:,:), zslpx(:,:,:)
+    real(wp), intent(out) :: zwx(:,:,:)
+    real(wp), intent(in) :: pwn(:,:,:), mydomain(:,:,:), zind(:,:,:), zslpx(:,:,:)
     integer, intent(in) :: ji,jj,jk
     ! local variables
-    real*8 :: z0w, zalpha, zw, zzwx, zzwy, zdt, zbtr
+    real(wp) :: z0w, zalpha, zw, zzwx, zzwy, zdt, zbtr
     !
     zdt = 1.d0
     zbtr = 1.d0

--- a/src/psykal/zwx_kern.f90
+++ b/src/psykal/zwx_kern.f90
@@ -1,24 +1,26 @@
 module zwx_kern_mod
 !
+use kind_params_mod, only : wp
+!
 implicit none
 !
-type, extends(kernel_type) :: zwx_type
-  type(arg), dimension(3) :: meta_args = (/ &
-    arg(WRITE, 3D, CU), &
-    arg(READ,  TMASK_3D), &
-    arg(READ,  3D, CT, STENCIL(D)) /)
-  integer :: ITERATES_OVER = 3D
-  integer :: INDEX_OFFSET = OFFSET_NE
-contains
-  procedure, nopass :: code => zwx_kern
-end type zwx_type
+!type, extends(kernel_type) :: zwx_type
+!  type(arg), dimension(3) :: meta_args = (/ &
+!    arg(WRITE, DIMS(3), CU), &
+!    arg(READ,  TMASK_3D), &
+!    arg(READ,  DIMS(3), CT, STENCIL(D)) /)
+!  integer :: ITERATES_OVER = DIMS(3)
+!  integer :: INDEX_OFFSET = OFFSET_NE
+!contains
+!  procedure, nopass :: code => zwx_kern
+!end type zwx_type
 !
 contains
   !
   subroutine zwx_kern(zwx,tmask,mydomain,ji,jj,jk)
     !
-    real*8, intent(out) :: zwx(:,:,:)
-    real*8, intent(in)  :: tmask(:,:,:), mydomain(:,:,:)
+    real(wp), intent(out) :: zwx(:,:,:)
+    real(wp), intent(in)  :: tmask(:,:,:), mydomain(:,:,:)
     integer, intent(in) :: ji,jj,jk
     !
     zwx(ji,jj,jk) = tmask(ji,jj,jk) * ( mydomain(ji,jj,jk-1) - mydomain(ji,jj,jk) )

--- a/src/psykal/zwx_kern.f90
+++ b/src/psykal/zwx_kern.f90
@@ -2,6 +2,17 @@ module zwx_kern_mod
 !
 implicit none
 !
+type, extends(kernel_type) :: zwx_type
+  type(arg), dimension(3) :: meta_args = (/ &
+    arg(WRITE, 3D, CU), &
+    arg(READ,  TMASK_3D), &
+    arg(READ,  3D, CT, STENCIL(D)) /)
+  integer :: ITERATES_OVER = 3D
+  integer :: INDEX_OFFSET = OFFSET_NE
+contains
+  procedure, nopass :: code => zwx_kern
+end type zwx_type
+!
 contains
   !
   subroutine zwx_kern(zwx,tmask,mydomain,ji,jj,jk)

--- a/src/psykal/zwxy2_kern.f90
+++ b/src/psykal/zwxy2_kern.f90
@@ -2,6 +2,22 @@ module zwxy2_kern_mod
 !
 implicit none
 !
+type, extends(kernel_type) :: zwxy2_type
+  type(arg), dimension(8) :: meta_args = (/ &
+    arg(WRITE, 3D, CU), &
+    arg(WRITE, 3D, CV), &
+    arg(READ,  3D, CU), &
+    arg(READ,  3D, CV), &
+    arg(READ,  3D, CT, STENCIL(NE)), &
+    arg(READ,  3D, CT), &
+    arg(READ,  3D, CU, STENCIL(E)), &
+    arg(READ,  3D, CV, STENCIL(N)) /)
+  integer :: ITERATES_OVER = 3D
+  integer :: INDEX_OFFSET = OFFSET_NE
+contains
+  procedure, nopass :: code => zwxy2_kern
+end type zwxy2_type
+!
 contains
   !
   subroutine zwxy2_kern(zwx,zwy,pun,pvn,mydomain,zind,zslpx,zslpy,ji,jj,jk)

--- a/src/psykal/zwxy2_kern.f90
+++ b/src/psykal/zwxy2_kern.f90
@@ -1,32 +1,34 @@
 module zwxy2_kern_mod
 !
+use kind_params_mod, only : wp
+!
 implicit none
 !
-type, extends(kernel_type) :: zwxy2_type
-  type(arg), dimension(8) :: meta_args = (/ &
-    arg(WRITE, 3D, CU), &
-    arg(WRITE, 3D, CV), &
-    arg(READ,  3D, CU), &
-    arg(READ,  3D, CV), &
-    arg(READ,  3D, CT, STENCIL(NE)), &
-    arg(READ,  3D, CT), &
-    arg(READ,  3D, CU, STENCIL(E)), &
-    arg(READ,  3D, CV, STENCIL(N)) /)
-  integer :: ITERATES_OVER = 3D
-  integer :: INDEX_OFFSET = OFFSET_NE
-contains
-  procedure, nopass :: code => zwxy2_kern
-end type zwxy2_type
+!type, extends(kernel_type) :: zwxy2_type
+!  type(arg), dimension(8) :: meta_args = (/ &
+!    arg(WRITE, DIMS(3), CU), &
+!    arg(WRITE, DIMS(3), CV), &
+!    arg(READ,  DIMS(3), CU), &
+!    arg(READ,  DIMS(3), CV), &
+!    arg(READ,  DIMS(3), CT, STENCIL(NE)), &
+!    arg(READ,  DIMS(3), CT), &
+!    arg(READ,  DIMS(3), CU, STENCIL(E)), &
+!    arg(READ,  DIMS(3), CV, STENCIL(N)) /)
+!  integer :: ITERATES_OVER = DIMS(3)
+!  integer :: INDEX_OFFSET = OFFSET_NE
+!contains
+!  procedure, nopass :: code => zwxy2_kern
+!end type zwxy2_type
 !
 contains
   !
   subroutine zwxy2_kern(zwx,zwy,pun,pvn,mydomain,zind,zslpx,zslpy,ji,jj,jk)
     !
-    real*8, intent(out) :: zwx(:,:,:), zwy(:,:,:)
-    real*8, intent(in)  :: pun(:,:,:), pvn(:,:,:), mydomain(:,:,:), zind(:,:,:), zslpx(:,:,:), zslpy(:,:,:)
+    real(wp), intent(out) :: zwx(:,:,:), zwy(:,:,:)
+    real(wp), intent(in)  :: pun(:,:,:), pvn(:,:,:), mydomain(:,:,:), zind(:,:,:), zslpx(:,:,:), zslpy(:,:,:)
     integer, intent(in) :: ji,jj,jk
     ! local variables
-    real*8 :: z0u, zalpha, zu, zzwx, zzwy, z0v, zv, zdt
+    real(wp) :: z0u, zalpha, zu, zzwx, zzwy, z0v, zv, zdt
     !
     zdt = 1.d0
     z0u = SIGN( 0.5d0, pun(ji,jj,jk) )

--- a/src/psykal/zwxy_kern.f90
+++ b/src/psykal/zwxy_kern.f90
@@ -2,6 +2,19 @@ module zwxy_kern_mod
 !
 implicit none
 !
+type, extends(kernel_type) :: zwxy_type
+  type(arg), dimension(5) :: meta_args = (/ &
+    arg(WRITE, 3D, CU), &
+    arg(WRITE, 3D, CV), &
+    arg(READ,  3D, CT, STENCIL(NE)), &
+    arg(READ,  3D, CU), &
+    arg(READ,  3D, CV) /)
+  integer :: ITERATES_OVER = 3D
+  integer :: INDEX_OFFSET = OFFSET_NE
+contains
+  procedure, nopass :: code => zwxy_kern
+end type zwxy_type
+!
 contains
   !
   subroutine zwxy_kern(zwx,zwy,mydomain,umask,vmask,ji,jj,jk)

--- a/src/psykal/zwxy_kern.f90
+++ b/src/psykal/zwxy_kern.f90
@@ -1,27 +1,29 @@
 module zwxy_kern_mod
 !
+use kind_params_mod, only : wp
+!
 implicit none
 !
-type, extends(kernel_type) :: zwxy_type
-  type(arg), dimension(5) :: meta_args = (/ &
-    arg(WRITE, 3D, CU), &
-    arg(WRITE, 3D, CV), &
-    arg(READ,  3D, CT, STENCIL(NE)), &
-    arg(READ,  3D, CU), &
-    arg(READ,  3D, CV) /)
-  integer :: ITERATES_OVER = 3D
-  integer :: INDEX_OFFSET = OFFSET_NE
-contains
-  procedure, nopass :: code => zwxy_kern
-end type zwxy_type
+!type, extends(kernel_type) :: zwxy_type
+!  type(arg), dimension(5) :: meta_args = (/ &
+!    arg(WRITE, DIMS(3), CU), &
+!    arg(WRITE, DIMS(3), CV), &
+!    arg(READ,  DIMS(3), CT, STENCIL(NE)), &
+!    arg(READ,  DIMS(3), CU), &
+!    arg(READ,  DIMS(3), CV) /)
+!  integer :: ITERATES_OVER = DIMS(3)
+!  integer :: INDEX_OFFSET = OFFSET_NE
+!contains
+!  procedure, nopass :: code => zwxy_kern
+!end type zwxy_type
 !
 contains
   !
   subroutine zwxy_kern(zwx,zwy,mydomain,umask,vmask,ji,jj,jk)
     !
-    real*8,  intent(out) :: zwx(:,:,:), zwy(:,:,:)
-    real*8,  intent(in)  :: mydomain(:,:,:)
-    real*8,  intent(in)  :: umask(:,:,:), vmask(:,:,:)
+    real(wp),  intent(out) :: zwx(:,:,:), zwy(:,:,:)
+    real(wp),  intent(in)  :: mydomain(:,:,:)
+    real(wp),  intent(in)  :: umask(:,:,:), vmask(:,:,:)
     integer, intent(in) :: ji,jj,jk
     !
     zwx(ji,jj,jk) = umask(ji,jj,jk) * ( mydomain(ji+1,jj,jk) - mydomain(ji,jj,jk) )


### PR DESCRIPTION
I've added some Kernel metadata for discussion. I've commented this out as it needs changes in dl_esm_inf in order to compile. I've also taken this opportunity to change real*8 to real(wp) in the Kernels.

The main metadata changes are
1) Adding dimension information for fields: DIMS(2) for example
2) Adding stencil information with stencil direction for fields: STENCIL(N) for example
3) Adding 3D properties for arguments : TMASK_3D for example
4) Make iterates over specify dimension information : DIMS(3) for example